### PR TITLE
Make canvas fill viewport initially

### DIFF
--- a/helperFunctions.js
+++ b/helperFunctions.js
@@ -15,6 +15,10 @@ function refreshPattern() {
   timeOffset = performance.now();
   randomSeed = Math.floor(Math.random() * 1000,0);
   gl.uniform1f(seedLocation, randomSeed);
+  
+  // Ensure resolution uniform is updated
+  gl.uniform2f(resolutionLocation, canvas.width, canvas.height);
+  
   if(!isPlaying){
     isPlaying = true;
     animationID = requestAnimationFrame(render);
@@ -134,6 +138,9 @@ function updateCanvasSize() {
   // Update the WebGL viewport to match
   gl.viewport(0, 0, canvas.width, canvas.height);
   
+  // Update the resolution uniform in the shader
+  gl.uniform2f(resolutionLocation, canvas.width, canvas.height);
+  
   // Re-render if not already playing
   if (!isPlaying) {
       drawScene();
@@ -148,6 +155,7 @@ function updateCanvasSize() {
 
 window.addEventListener('resize', function() {
   gl.viewport(0, 0, canvas.width, canvas.height);
+  gl.uniform2f(resolutionLocation, canvas.width, canvas.height);
 });
 
 document.getElementById('randomizeBtn').addEventListener('click', () => randomizeInputs());

--- a/main.js
+++ b/main.js
@@ -9,8 +9,11 @@ Generate perfect loops in x seconds
 
 // Initialize WebGL context
 const canvas = document.getElementById('canvas');
-let startingWidth = 1000;
-let startingHeight = Math.round(Math.max(1000, Math.min(4000, startingWidth * (window.innerHeight/window.innerWidth))) / 4) * 4;
+let startingWidth = window.innerWidth;
+let startingHeight = window.innerHeight;
+// Round to multiples of 4 for better video encoding compatibility
+startingWidth = Math.round(startingWidth / 4) * 4;
+startingHeight = Math.round(startingHeight / 4) * 4;
 canvas.width = startingWidth;
 canvas.height = startingHeight;
 console.log("canvas width/height: "+canvas.width+" / "+canvas.height);
@@ -116,6 +119,37 @@ const params = {
 
 // Also refresh on page load
 window.addEventListener('load', refreshPattern);
+
+// Add resize event listener to adjust canvas size when window is resized
+window.addEventListener('resize', function() {
+    // Only auto-resize if the canvas is currently at full viewport size
+    if (canvas.width === Math.round(window.innerWidth / 4) * 4 &&
+        canvas.height === Math.round(window.innerHeight / 4) * 4) {
+        // Update to new viewport size
+        let newWidth = window.innerWidth;
+        let newHeight = window.innerHeight;
+        // Round to multiples of 4 for better video encoding compatibility
+        newWidth = Math.round(newWidth / 4) * 4;
+        newHeight = Math.round(newHeight / 4) * 4;
+        
+        // Update canvas and params
+        canvas.width = newWidth;
+        canvas.height = newHeight;
+        params.canvasWidth = newWidth;
+        params.canvasHeight = newHeight;
+        
+        // Update WebGL viewport
+        gl.viewport(0, 0, canvas.width, canvas.height);
+        
+        // Update shader uniforms with new resolution
+        gl.uniform2f(resolutionLocation, canvas.width, canvas.height);
+        
+        // Force a redraw
+        drawScene();
+        
+        console.log("Resized canvas to: " + canvas.width + " / " + canvas.height);
+    }
+});
 
 // Initialize dat.gui
 const gui = new dat.GUI({ autoplace: false });

--- a/styles.css
+++ b/styles.css
@@ -13,11 +13,11 @@ html, body{
 canvas {
     display: block;
     max-width: 100%;
+    max-height: 100vh;
     margin: 0 auto;
     padding: 0;
-    /* margin-top: 0vh; */
     text-align: center;
-    /* height: 100vh; */
+    object-fit: contain;
 }
 
 #refreshButton {


### PR DESCRIPTION
This PR updates the project to make the canvas size start off by filling the viewport.

### Changes:

1. **Canvas Initialization**:
   - Changed the canvas initialization to use `window.innerWidth` and `window.innerHeight` instead of fixed values
   - Rounded the dimensions to multiples of 4 for better video encoding compatibility

2. **Responsive Behavior**:
   - Added a window resize event listener that automatically resizes the canvas when the window size changes
   - The resize handler only activates if the canvas is currently at full viewport size
   - When resizing, it updates both the canvas dimensions and the params object values

3. **Visualization Updates**:
   - Updated the `updateCanvasSize` function to set the resolution uniform
   - Enhanced the `refreshPattern` function to ensure it updates the resolution uniform
   - Improved resize event listeners to properly update the WebGL viewport and force redraws

4. **CSS Improvements**:
   - Added `max-height: 100vh` to ensure the canvas doesn't exceed the viewport height
   - Added `object-fit: contain` to maintain the aspect ratio when scaling

These changes ensure that:
- The canvas starts at the exact size of the viewport
- The canvas automatically adjusts when the window is resized
- The shader uniforms are updated with the new resolution when resizing
- The visualization properly updates to match the canvas size

The canvas will now fill the viewport when the page loads, providing a more immersive experience for users. The automatic resizing also makes the application more responsive to different screen sizes and window adjustments.